### PR TITLE
Opentelemetry tags for bound statements

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -67,6 +67,15 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setStatement(String statement, int limit) {}
 
     @Override
+    public void setKeyspace(String keyspace) {}
+
+    @Override
+    public void setPartitionKey(String partitionKey) {}
+
+    @Override
+    public void setTable(String table) {}
+
+    @Override
     public void recordException(Exception exception) {}
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -17,6 +17,9 @@
 package com.datastax.driver.core.tracing;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import java.net.InetAddress;
 
 public class NoopTracingInfoFactory implements TracingInfoFactory {
 
@@ -29,6 +32,39 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
 
     @Override
     public void setStatementType(String statementType) {}
+
+    @Override
+    public void setRetryPolicy(RetryPolicy retryPolicy) {}
+
+    @Override
+    public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {};
+
+    @Override
+    public void setBatchSize(int batchSize) {}
+
+    @Override
+    public void setRetryCount(int retryCount) {}
+
+    @Override
+    public void setShardID(int shardID) {}
+
+    @Override
+    public void setPeerName(String peerName) {}
+
+    @Override
+    public void setPeerIP(InetAddress peerIP) {}
+
+    @Override
+    public void setPeerPort(int peerPort) {}
+
+    @Override
+    public void setQueryPaged(Boolean queryPaged) {}
+
+    @Override
+    public void setRowsCount(int rowsCount) {}
+
+    @Override
+    public void setStatement(String statement, int limit) {}
 
     @Override
     public void recordException(Exception exception) {}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -135,6 +135,27 @@ public interface TracingInfo {
   void setStatement(String statement, int limit);
 
   /**
+   * Adds provided keyspace to the trace.
+   *
+   * @param keyspace the keyspace to be set.
+   */
+  void setKeyspace(String keyspace);
+
+  /**
+   * Adds provided partition key string to the trace.
+   *
+   * @param partitionKey the partitionKey to be set.
+   */
+  void setPartitionKey(String partitionKey);
+
+  /**
+   * Adds provided table name to the trace.
+   *
+   * @param table the table name to be set.
+   */
+  void setTable(String table);
+
+  /**
    * Records in the trace that the provided exception occured.
    *
    * @param exception the exception to be recorded.

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -17,6 +17,9 @@
 package com.datastax.driver.core.tracing;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import java.net.InetAddress;
 
 /**
  * An abstraction layer over instrumentation library API, corresponding to a logical span in the
@@ -48,9 +51,88 @@ public interface TracingInfo {
   /**
    * Adds provided statement type to the trace.
    *
-   * @param statementType the statementType to be set.
+   * @param statementType the statement type to be set.
    */
   void setStatementType(String statementType);
+
+  /**
+   * Adds provided retry policy to the trace.
+   *
+   * @param retryPolicy the retry policy to be set.
+   */
+  void setRetryPolicy(RetryPolicy retryPolicy);
+
+  /**
+   * Adds provided load balancing policy to the trace.
+   *
+   * @param loadBalancingPolicy the load balancing policy to be set.
+   */
+  void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy);
+
+  /**
+   * Adds provided batch size to the trace.
+   *
+   * @param batchSize the batch size to be set.
+   */
+  void setBatchSize(int batchSize);
+
+  /**
+   * Adds provided retry count to the trace.
+   *
+   * @param retryCount the retry count to be set.
+   */
+  void setRetryCount(int retryCount);
+
+  /**
+   * Adds provided shard ID to the trace.
+   *
+   * @param shardID the shard ID to be set.
+   */
+  void setShardID(int shardID);
+
+  /**
+   * Adds provided peer name to the trace.
+   *
+   * @param peerName the peer name to be set.
+   */
+  void setPeerName(String peerName);
+
+  /**
+   * Adds provided peer IP to the trace.
+   *
+   * @param peerIP the peer IP to be set.
+   */
+  void setPeerIP(InetAddress peerIP);
+
+  /**
+   * Adds provided peer port to the trace.
+   *
+   * @param peerPort the peer port to be set.
+   */
+  void setPeerPort(int peerPort);
+
+  /**
+   * Adds information whether the query was paged to the trace.
+   *
+   * @param queryPaged information whether the query was paged.
+   */
+  void setQueryPaged(Boolean queryPaged);
+
+  /**
+   * Adds provided number of returned rows to the trace.
+   *
+   * @param rowsCount the number of returned rows to be set.
+   */
+  void setRowsCount(int rowsCount);
+
+  /**
+   * Adds provided statement text to the trace. If the statement length is greater than given limit,
+   * the statement is trimmed to the first {@param limit} signs.
+   *
+   * @param statement the statement text to be set.
+   * @param limit the statement length limit.
+   */
+  void setStatement(String statement, int limit);
 
   /**
    * Records in the trace that the provided exception occured.

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/BasicTracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/BasicTracingTest.java
@@ -16,12 +16,18 @@
 
 package com.datastax.driver.core.tracing;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.DefaultRetryPolicy;
+import com.datastax.driver.core.policies.PagingOptimizingLoadBalancingPolicy;
+import java.util.ArrayList;
 import java.util.Collection;
 import org.testng.annotations.Test;
 
@@ -49,6 +55,94 @@ public class BasicTracingTest extends CCMTestsSupport {
     assertTrue(root.isSpanStarted());
     assertTrue(root.isSpanFinished());
     assertEquals(root.getStatusCode(), TracingInfo.StatusCode.OK);
+
+    spans.clear();
+  }
+
+  @Test(groups = "short")
+  public void tagsTest() {
+    session().execute("INSERT INTO t(k, v) VALUES (4, 2)");
+
+    Collection<TracingInfo> spans = testTracingInfoFactory.getSpans();
+    assertNotEquals(spans.size(), 0);
+
+    TracingInfo rootSpan = getRoot(spans);
+    assertTrue(rootSpan instanceof TestTracingInfo);
+    TestTracingInfo root = (TestTracingInfo) rootSpan;
+
+    assertTrue(root.isSpanStarted());
+    assertTrue(root.isSpanFinished());
+    assertEquals(root.getStatusCode(), TracingInfo.StatusCode.OK);
+
+    // these tags should be set for request span
+    assertEquals(root.getStatementType(), "regular");
+    assertEquals(root.getBatchSize(), new Integer(1));
+    assertEquals(root.getConsistencyLevel(), ConsistencyLevel.ONE);
+    assertNull(root.getRowsCount()); // no rows are returned in insert
+    assertTrue(root.getLoadBalancingPolicy() instanceof PagingOptimizingLoadBalancingPolicy);
+    assertTrue(root.getRetryPolicy() instanceof DefaultRetryPolicy);
+    assertFalse(root.getQueryPaged());
+    assertNull(root.getStatement()); // because of precision level NORMAL
+
+    // these tags should not be set for request span
+    assertNull(root.getPeerName());
+    assertNull(root.getPeerIP());
+    assertNull(root.getPeerPort());
+    assertNull(root.getRetryCount());
+
+    ArrayList<TracingInfo> speculativeExecutions = getChildren(spans, root);
+    assertTrue(speculativeExecutions.size() > 0);
+
+    for (TracingInfo speculativeExecutionSpan : speculativeExecutions) {
+      assertTrue(speculativeExecutionSpan instanceof TestTracingInfo);
+      TestTracingInfo tracingInfo = (TestTracingInfo) speculativeExecutionSpan;
+
+      // these tags should not be set for speculative execution span
+      assertNull(tracingInfo.getStatementType());
+      assertNull(tracingInfo.getBatchSize());
+      assertNull(tracingInfo.getConsistencyLevel());
+      assertNull(tracingInfo.getRowsCount());
+      assertNull(tracingInfo.getLoadBalancingPolicy());
+      assertNull(tracingInfo.getRetryPolicy());
+      assertNull(tracingInfo.getQueryPaged());
+      assertNull(tracingInfo.getStatement());
+      assertNull(tracingInfo.getPeerName());
+      assertNull(tracingInfo.getPeerIP());
+      assertNull(tracingInfo.getPeerPort());
+
+      // this tag should be set for speculative execution span
+      assertTrue(tracingInfo.getRetryCount() >= 0);
+    }
+
+    ArrayList<TracingInfo> queries = new ArrayList<TracingInfo>();
+    for (TracingInfo tracingInfo : speculativeExecutions) {
+      queries.addAll(getChildren(spans, tracingInfo));
+    }
+    assertTrue(queries.size() > 0);
+
+    for (TracingInfo querySpan : queries) {
+      assertTrue(querySpan instanceof TestTracingInfo);
+      TestTracingInfo tracingInfo = (TestTracingInfo) querySpan;
+
+      // these tags should not be set for query span
+      assertNull(tracingInfo.getStatementType());
+      assertNull(tracingInfo.getBatchSize());
+      assertNull(tracingInfo.getConsistencyLevel());
+      assertNull(tracingInfo.getRowsCount());
+      assertNull(tracingInfo.getLoadBalancingPolicy());
+      assertNull(tracingInfo.getRetryPolicy());
+      assertNull(tracingInfo.getQueryPaged());
+      assertNull(tracingInfo.getStatement());
+      assertNull(tracingInfo.getRetryCount());
+
+      // these tags should be set for query span
+      assertNotNull(tracingInfo.getPeerName());
+      assertNotNull(tracingInfo.getPeerIP());
+      assertNotNull(tracingInfo.getPeerPort());
+      assertTrue(tracingInfo.getPeerPort() >= 0 && tracingInfo.getPeerPort() <= 65535);
+    }
+
+    spans.clear();
   }
 
   private void initializeTestTracing() {
@@ -67,5 +161,16 @@ public class BasicTracingTest extends CCMTestsSupport {
     }
 
     return root;
+  }
+
+  private ArrayList<TracingInfo> getChildren(Collection<TracingInfo> spans, TracingInfo parent) {
+    ArrayList<TracingInfo> children = new ArrayList<TracingInfo>();
+    for (TracingInfo tracingInfo : spans) {
+      if (tracingInfo instanceof TestTracingInfo
+          && ((TestTracingInfo) tracingInfo).getParent() == parent) {
+        children.add(tracingInfo);
+      }
+    }
+    return children;
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -28,8 +28,8 @@ public class TestTracingInfo implements TracingInfo {
   private final PrecisionLevel precision;
   private TracingInfo parent = null;
 
-  private boolean spanStarted = false;
-  private boolean spanFinished = false;
+  private Boolean spanStarted = false;
+  private Boolean spanFinished = false;
   private String spanName;
   private ConsistencyLevel consistencyLevel;
   private String statement;
@@ -40,13 +40,13 @@ public class TestTracingInfo implements TracingInfo {
   private InetAddress peerIP;
   private RetryPolicy retryPolicy;
   private LoadBalancingPolicy loadBalancingPolicy;
-  private int batchSize;
-  private int retryCount;
-  private int shardID;
+  private Integer batchSize;
+  private Integer retryCount;
+  private Integer shardID;
   private String peerName;
-  private int peerPort;
+  private Integer peerPort;
   private Boolean queryPaged;
-  private int rowsCount;
+  private Integer rowsCount;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -191,15 +191,15 @@ public class TestTracingInfo implements TracingInfo {
     return loadBalancingPolicy;
   }
 
-  public int getBatchSize() {
+  public Integer getBatchSize() {
     return batchSize;
   }
 
-  public int getRetryCount() {
+  public Integer getRetryCount() {
     return retryCount;
   }
 
-  public int getShardID() {
+  public Integer getShardID() {
     return shardID;
   }
 
@@ -211,7 +211,7 @@ public class TestTracingInfo implements TracingInfo {
     return peerIP;
   }
 
-  public int getPeerPort() {
+  public Integer getPeerPort() {
     return peerPort;
   }
 
@@ -219,7 +219,7 @@ public class TestTracingInfo implements TracingInfo {
     return queryPaged;
   }
 
-  public int getRowsCount() {
+  public Integer getRowsCount() {
     return rowsCount;
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -47,6 +47,9 @@ public class TestTracingInfo implements TracingInfo {
   private Integer peerPort;
   private Boolean queryPaged;
   private Integer rowsCount;
+  private String keyspace;
+  private String partitionKey;
+  private String table;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -133,6 +136,21 @@ public class TestTracingInfo implements TracingInfo {
       if (statement.length() > limit) statement = statement.substring(0, limit);
       this.statement = statement;
     }
+  }
+
+  @Override
+  public void setKeyspace(String keyspace) {
+    this.keyspace = keyspace;
+  }
+
+  @Override
+  public void setPartitionKey(String partitionKey) {
+    this.partitionKey = partitionKey;
+  }
+
+  @Override
+  public void setTable(String table) {
+    this.table = table;
   }
 
   @Override
@@ -225,6 +243,18 @@ public class TestTracingInfo implements TracingInfo {
 
   public String getStatement() {
     return statement;
+  }
+
+  public String getKeyspace() {
+    return keyspace;
+  }
+
+  public String getPartitionKey() {
+    return partitionKey;
+  }
+
+  public String getTable() {
+    return table;
   }
 
   public StatusCode getStatusCode() {

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -17,6 +17,9 @@
 package com.datastax.driver.core.tracing;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -30,11 +33,20 @@ public class TestTracingInfo implements TracingInfo {
   private String spanName;
   private ConsistencyLevel consistencyLevel;
   private String statement;
-  private String hostname;
   private String statementType;
   private Collection<Exception> exceptions;
   private StatusCode statusCode;
   private String description;
+  private InetAddress peerIP;
+  private RetryPolicy retryPolicy;
+  private LoadBalancingPolicy loadBalancingPolicy;
+  private int batchSize;
+  private int retryCount;
+  private int shardID;
+  private String peerName;
+  private int peerPort;
+  private Boolean queryPaged;
+  private int rowsCount;
 
   public TestTracingInfo(PrecisionLevel precision) {
     this.precision = precision;
@@ -60,21 +72,67 @@ public class TestTracingInfo implements TracingInfo {
     this.consistencyLevel = consistency;
   }
 
-  public void setStatement(String statement) {
-    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
-      this.statement = statement;
-    }
-  }
-
-  public void setHostname(String hostname) {
-    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
-      this.hostname = hostname;
-    }
-  }
-
   @Override
   public void setStatementType(String statementType) {
     this.statementType = statementType;
+  }
+
+  @Override
+  public void setRetryPolicy(RetryPolicy retryPolicy) {
+    this.retryPolicy = retryPolicy;
+  }
+
+  @Override
+  public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {
+    this.loadBalancingPolicy = loadBalancingPolicy;
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void setRetryCount(int retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  @Override
+  public void setShardID(int shardID) {
+    this.shardID = shardID;
+  }
+
+  @Override
+  public void setPeerName(String peerName) {
+    this.peerName = peerName;
+  }
+
+  @Override
+  public void setPeerIP(InetAddress peerIP) {
+    this.peerIP = peerIP;
+  }
+
+  @Override
+  public void setPeerPort(int peerPort) {
+    this.peerPort = peerPort;
+  }
+
+  @Override
+  public void setQueryPaged(Boolean queryPaged) {
+    this.queryPaged = queryPaged;
+  }
+
+  @Override
+  public void setRowsCount(int rowsCount) {
+    this.rowsCount = rowsCount;
+  }
+
+  @Override
+  public void setStatement(String statement, int limit) {
+    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
+      if (statement.length() > limit) statement = statement.substring(0, limit);
+      this.statement = statement;
+    }
   }
 
   @Override
@@ -121,16 +179,52 @@ public class TestTracingInfo implements TracingInfo {
     return consistencyLevel;
   }
 
-  public String getStatement() {
-    return statement;
-  }
-
-  public String getHostname() {
-    return hostname;
-  }
-
   public String getStatementType() {
     return statementType;
+  }
+
+  public RetryPolicy getRetryPolicy() {
+    return retryPolicy;
+  }
+
+  public LoadBalancingPolicy getLoadBalancingPolicy() {
+    return loadBalancingPolicy;
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public int getRetryCount() {
+    return retryCount;
+  }
+
+  public int getShardID() {
+    return shardID;
+  }
+
+  public String getPeerName() {
+    return peerName;
+  }
+
+  public InetAddress getPeerIP() {
+    return peerIP;
+  }
+
+  public int getPeerPort() {
+    return peerPort;
+  }
+
+  public Boolean getQueryPaged() {
+    return queryPaged;
+  }
+
+  public int getRowsCount() {
+    return rowsCount;
+  }
+
+  public String getStatement() {
+    return statement;
   }
 
   public StatusCode getStatusCode() {

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -160,6 +160,24 @@ public class OpenTelemetryTracingInfo implements TracingInfo {
     }
   }
 
+  @Override
+  public void setKeyspace(String keyspace) {
+    assertStarted();
+    span.setAttribute("db.scylla.keyspace", keyspace);
+  }
+
+  @Override
+  public void setPartitionKey(String partitionKey) {
+    assertStarted();
+    span.setAttribute("db.scylla.partition_key", partitionKey);
+  }
+
+  @Override
+  public void setTable(String table) {
+    assertStarted();
+    span.setAttribute("db.scylla.table", table);
+  }
+
   private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
     switch (code) {
       case OK:


### PR DESCRIPTION
The PR extends tracing capabilities using OpenTelemetry standard by implementing OTel tags specific to bound statements. Additional information about the bound statement such as keyspace, table name and partition key is added to the trace.
The implementation was tested with standard tests run by Maven during build, as well as by checking it performance using the added ZipkinUsage example